### PR TITLE
Build essentia debian docker image

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,24 @@
+FROM debian:jessie
+
+RUN apt-get update \
+    && apt-get install -y libyaml-0-2 libfftw3-3 libtag1c2a libsamplerate0 \
+       libavcodec56 libavformat56 libavutil54 \
+       libavresample2 python python-numpy libpython2.7 python-numpy python-yaml \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update \
+    && apt-get install -y build-essential libyaml-dev libfftw3-dev \
+       libavcodec-dev libavformat-dev libavutil-dev libavresample-dev \
+       python-dev libsamplerate0-dev libtag1-dev python-numpy-dev git \
+    && mkdir /essentia && cd /essentia && git clone https://github.com/MTG/essentia.git \
+    && cd /essentia/essentia && ./waf configure --with-examples --with-python --with-vamp \
+    && ./waf && ./waf install && ldconfig \
+    &&  apt-get remove -y build-essential libyaml-dev libfftw3-dev libavcodec-dev \
+        libavformat-dev libavutil-dev libavresample-dev python-dev libsamplerate0-dev \
+        libtag1-dev python-numpy-dev \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && cd / && rm -rf /essentia/essentia
+
+WORKDIR /essentia


### PR DESCRIPTION
A docker image of essentia based on debian was needed for music-critic to agree dependencies on different debian docker images.
Builds docker image based on debian with the correct package names for libav and taglib 