### PR TITLE
Python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:16.04
 RUN apt-get update \
     && apt-get install -y libyaml-0-2 libfftw3-3 libtag1v5 libsamplerate0 \
        libavcodec-ffmpeg56 libavformat-ffmpeg56 libavutil-ffmpeg54 \
-       libavresample-ffmpeg2 python python-numpy libpython2.7 python-numpy python-yaml \
+       libavresample-ffmpeg2 python python-numpy libpython2.7 python-yaml \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update \

--- a/Dockerfile.python3
+++ b/Dockerfile.python3
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ENV LANG C.UTF-8
+
 RUN apt-get update && apt-get -y upgrade
 
 RUN apt-get install -y build-essential libssl-dev libffi-dev python3-dev
@@ -7,13 +9,14 @@ RUN apt-get install -y build-essential libssl-dev libffi-dev python3-dev
 RUN apt-get update \
     && apt-get install -y build-essential libyaml-dev libfftw3-dev \
     libavcodec-dev libavformat-dev libavutil-dev libavresample-dev python-dev \
-    libsamplerate0-dev libtag1-dev python-numpy-dev python-numpy python-yaml\
+    libsamplerate0-dev libtag1-dev python-numpy-dev python-numpy python3-pip python-yaml\
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && apt-get install -y git && mkdir /essentia \
     && cd /essentia && git clone https://github.com/MTG/essentia.git
-RUN cd /essentia/essentia && /usr/bin/python3 waf configure --with-python
-RUN python3 waf && python3 waf install && ldconfig \
+RUN pip3 install --upgrade pip && pip3 install numpy
+RUN cd /essentia/essentia && python3 waf configure --with-python \
+    && python3 waf && python3 waf install && ldconfig \
     &&  apt-get remove -y build-essential libyaml-dev libfftw3-dev libavcodec-dev \
         libavformat-dev libavutil-dev libavresample-dev python-dev libsamplerate0-dev \
         libtag1-dev python-numpy-dev \

--- a/Dockerfile.python3
+++ b/Dockerfile.python3
@@ -2,20 +2,17 @@ FROM ubuntu:16.04
 
 ENV LANG C.UTF-8
 
-RUN apt-get update && apt-get -y upgrade
-
-RUN apt-get install -y build-essential libssl-dev libffi-dev python3-dev
+RUN apt-get update && apt-get install -y python3-numpy python3-six \
+    libfftw3-3 libyaml-0-2 libtag1v5 libsamplerate0 libavcodec-ffmpeg56 \
+    libavformat-ffmpeg56 libavutil-ffmpeg54 \
+    libavresample-ffmpeg2 python3-yaml
 
 RUN apt-get update \
-    && apt-get install -y build-essential libyaml-dev libfftw3-dev \
-    libavcodec-dev libavformat-dev libavutil-dev libavresample-dev python-dev \
-    libsamplerate0-dev libtag1-dev python-numpy-dev python-numpy python3-pip python-yaml\
-    && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update && apt-get install -y git && mkdir /essentia \
-    && cd /essentia && git clone https://github.com/MTG/essentia.git
-RUN pip3 install --upgrade pip && pip3 install numpy
-RUN cd /essentia/essentia && python3 waf configure --with-python \
+    && apt-get install -y build-essential python3-dev git \
+    libfftw3-dev libavcodec-dev libavformat-dev libavresample-dev \
+    libsamplerate0-dev libtag1-dev libyaml-dev \
+    && mkdir /essentia && cd /essentia && git clone https://github.com/MTG/essentia.git \
+    && cd /essentia/essentia && python3 waf configure --with-python \
     && python3 waf && python3 waf install && ldconfig \
     &&  apt-get remove -y build-essential libyaml-dev libfftw3-dev libavcodec-dev \
         libavformat-dev libavutil-dev libavresample-dev python-dev libsamplerate0-dev \
@@ -24,3 +21,8 @@ RUN cd /essentia/essentia && python3 waf configure --with-python \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* \
     && cd / && rm -rf /essentia/essentia
+
+
+ENV PYTHONPATH /usr/local/lib/python3/dist-packages
+
+WORKDIR /essentia

--- a/Dockerfile.python3
+++ b/Dockerfile.python3
@@ -1,0 +1,23 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get -y upgrade
+
+RUN apt-get install -y build-essential libssl-dev libffi-dev python3-dev
+
+RUN apt-get update \
+    && apt-get install -y build-essential libyaml-dev libfftw3-dev \
+    libavcodec-dev libavformat-dev libavutil-dev libavresample-dev python-dev \
+    libsamplerate0-dev libtag1-dev python-numpy-dev python-numpy python-yaml\
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y git && mkdir /essentia \
+    && cd /essentia && git clone https://github.com/MTG/essentia.git
+RUN cd /essentia/essentia && /usr/bin/python3 waf configure --with-python
+RUN python3 waf && python3 waf install && ldconfig \
+    &&  apt-get remove -y build-essential libyaml-dev libfftw3-dev libavcodec-dev \
+        libavformat-dev libavutil-dev libavresample-dev python-dev libsamplerate0-dev \
+        libtag1-dev python-numpy-dev \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && cd / && rm -rf /essentia/essentia


### PR DESCRIPTION
Create an essentia python3 docker image base on ubuntu 16.04.

Even if the building works as well as the image, it seems there is some problem reagarding where dependencies are installed. Essentia is installed in /usr/local/lib/python3/dist-packages while things installed with pip go into /usr/local/lib/python3.5/dist-packages. As the first path is not in the python path, I'm adding it in https://github.com/MTG/essentia-docker/blob/python3/Dockerfile.python3#L26 